### PR TITLE
Change e.pageX and e.pageY to e.clientX and e.clientY to solve bug wh…

### DIFF
--- a/packages/lib/src/components/VPerfectSignature.ts
+++ b/packages/lib/src/components/VPerfectSignature.ts
@@ -54,8 +54,8 @@ export default defineComponent({
 
             const canvas = e.composedPath()[0] as HTMLCanvasElement
             const rect = canvas.getBoundingClientRect()
-            const x = e.pageX - rect.left
-            const y = e.pageY - rect.top
+            const x = e.clientX - rect.left
+            const y = e.clientY - rect.top
 
             this.currentInputPoints = [[x, y, e.pressure]]
             this.isDrawing = true
@@ -69,8 +69,8 @@ export default defineComponent({
 
                 const canvas = e.composedPath()[0] as HTMLCanvasElement
                 const rect = canvas.getBoundingClientRect()
-                const x = e.pageX - rect.left
-                const y = e.pageY - rect.top
+                const x = e.clientX - rect.left
+                const y = e.clientY - rect.top
 
                 this.currentInputPoints = [...this.currentInputPoints ?? [], [x, y, e.pressure]]
             }


### PR DESCRIPTION
In some cases, the component does not work correctly, because it takes coordinates using the whole window as a reference. Looking for a solution for this, I have seen that substituting pageX and pageY for clientX and clientY uses relative coordinates, and then it works fine. I leave you the reference consulted below

https://salesforce.stackexchange.com/questions/80033/canvas-signature-capture-issue-on-page-scroll

Sorry for my English. I am Spanish and I am not used to expressing myself in this language.
All the best.