### PR TITLE
feat: allow locking and unlocking of signature

### DIFF
--- a/src/components/VPerfectSignature.ts
+++ b/src/components/VPerfectSignature.ts
@@ -50,6 +50,7 @@ export default defineComponent({
     allInputPoints: [] as InputPoints[][],
     currentInputPoints: null as InputPoints[] | null,
     isDrawing: false,
+    isLocked: false,
     cachedImages: [] as HTMLImageElement[],
   }),
   watch: {
@@ -80,6 +81,8 @@ export default defineComponent({
   },
   methods: {
     handlePointerDown(e: PointerEvent) {
+      if (this.isLocked) return
+
       e.preventDefault()
 
       const canvas = e.composedPath()[0] as HTMLCanvasElement
@@ -92,6 +95,7 @@ export default defineComponent({
       this.$emit('onBegin', e)
     },
     handlePointerMove(e: PointerEvent) {
+      if (this.isLocked) return
       if (!this.isDrawing) return
 
       if (e.buttons === 1) {
@@ -109,6 +113,8 @@ export default defineComponent({
       }
     },
     handlePointerUp(e: PointerEvent) {
+      if (this.isLocked) return
+
       e.preventDefault()
       this.isDrawing = false
 
@@ -120,10 +126,13 @@ export default defineComponent({
       this.$emit('onEnd', e)
     },
     handlePointerEnter(e: PointerEvent) {
+      if (this.isLocked) return
+
       if (e.buttons === 1)
         this.handlePointerDown(e)
     },
     handlePointerLeave(e: PointerEvent) {
+      if (this.isLocked) return
       if (!this.isDrawing) return
       this.handlePointerUp(e)
     },
@@ -137,6 +146,12 @@ export default defineComponent({
     },
     fromData(data: InputPoints[][]) {
       this.allInputPoints = [...this.allInputPoints, ...data]
+    },
+    lock() {
+      this.isLocked = true
+    },
+    unlock() {
+      this.isLocked = false
     },
     toData() {
       return this.allInputPoints


### PR DESCRIPTION
Hi, thanks for this component. I previously was using `vue-signature-pad` and this one seems to work much more reliably.

One feature that I'm missing is the ability to lock and unlock the canvas. I use this to show a previously drawn signature but not allow any changes to it.

This PR adds this simple functionality. 

Example usage:

```
[..]
const signature = ref<typeof VPerfectSignature>()
const isReadOnly = true // some setting
const savedSignature = "data/img....blbalba"

onMounted(() => {
  signature.fromDataURL(savedSignature)
  if (isReadOnly) signature.lock()
})
```